### PR TITLE
add support for gitlab and add auto-detection of webhook type

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Webhook Connector between Repo and Grunt Build Machine
 **Currently Supports**
 - CodebaseHQ
 - Github
+- Gitlab
 
 ## Configuration
 - Clone this into a web accessible folder and run `composer install`.  

--- a/app-config.sample.php
+++ b/app-config.sample.php
@@ -1,14 +1,5 @@
 <?php
 /**
- * Indicate what type of repository is sending the webhook.
- * Currently supports:
- * - codebase
- * - github
- */
-$repository_type = 'codebase';
-
-
-/**
  * This is used to indicate what email address is used by the git user that the grunt build machine makes commits with.
  *  This allows the webhook to detect the most recent commit and prevent recursive commits.
  *

--- a/inc/Config.php
+++ b/inc/Config.php
@@ -17,7 +17,6 @@ class Config
     public $grunt_path = '';
     public $grunt_src = '';
     public $server_git_email = '';
-    public $repository_type = '';
 
 
     /**
@@ -32,7 +31,6 @@ class Config
         $this->grunt_path = isset($grunt_path) ? $grunt_path : '';
         $this->grunt_src_path = isset($grunt_src_path) ? $grunt_src_path : '';
         $this->server_git_email = isset($server_git_email) ? $server_git_email : '';
-        $this->repository_type = isset($repository_type) ? $repository_type : '';
     }
 
     /**

--- a/inc/Http/AbstractRequest.php
+++ b/inc/Http/AbstractRequest.php
@@ -9,9 +9,17 @@ abstract class AbstractRequest implements RequestInterface
      */
     private $request;
 
+
+    /**
+     * Incoming content type for request.
+     * @var string
+     */
+    private $content_type;
+
     public function __construct(array $request)
     {
         $this->request = $request;
+        $this->content_type = isset($_SERVER['CONTENT_TYPE']) ? trim($_SERVER['CONTENT_TYPE']) : '';
     }
 
 
@@ -30,8 +38,18 @@ abstract class AbstractRequest implements RequestInterface
      */
     public function token()
     {
-        return isset($this->_request['token'])
-            ? $this->_request['token']
+        return isset($this->request['token'])
+            ? $this->request['token']
             : '';
+    }
+
+
+    /**
+     * Determine if this request has a json body.
+     *
+     */
+    public function isJson()
+    {
+        return strcasecmp($this->content_type, 'application/json') === 0;
     }
 }

--- a/inc/Http/GitlabRequest.php
+++ b/inc/Http/GitlabRequest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Nerrad\BuildMachine\WebHookListener\Http;
+
+use Exception;
+use stdClass;
+
+/**
+ * GitlabRequest
+ * GitlabRequest class for simply receiving the requests
+ *
+ * @package Nerrad\BuildMachine\WebHookListener\Http
+ * @author  Darren Ethier
+ * @since   1.0.0
+ */
+class GitlabRequest extends AbstractRequest
+{
+    /**
+     * Created from json.
+     * @var stdClass
+     */
+    private $payload;
+
+    /**
+     * GithubRequest constructor.
+     *
+     * @param array $request
+     * @throws Exception
+     */
+    public function __construct(array $request)
+    {
+        parent::__construct($request);
+        $this->setPayload();
+    }
+
+
+    /**
+     * @throws Exception
+     */
+    private function setPayload()
+    {
+        if (! $this->isJson()) {
+            throw new Exception('Unable to handle payload because the request is not a JSON POST');
+        }
+        //raw
+        $payload = trim(file_get_contents('php://input'));
+        $this->payload = json_decode($payload);
+    }
+
+    public function isValid()
+    {
+        return $this->payload !== null
+               && $this->cloneUrl()
+               && $this->url()
+               && $this->mostRecentCommitAuthorEmail()
+               && $this->branch();
+    }
+
+    /**
+     * @return string
+     */
+    public function cloneUrl()
+    {
+        return isset($this->payload->project, $this->payload->project->ssh_url)
+            ? $this->payload->project->ssh_url
+            : '';
+    }
+
+    /**
+     * The url to the web page for the repository.
+     *
+     * @return string
+     */
+    public function url()
+    {
+        return isset($this->payload->project, $this->payload->project->homepage)
+            ? $this->payload->project->homepage
+            : '';
+    }
+
+    /**
+     * Returns the author email for the most recent commit.
+     *
+     * @return string
+     */
+    public function mostRecentCommitAuthorEmail()
+    {
+        if (isset($this->payload->commits)) {
+            $commit = reset($this->payload->commits);
+            if (isset($commit->author, $commit->author->email)) {
+                return $commit->author->email;
+            }
+        }
+        return '';
+    }
+
+    /**
+     * The branch represented by the commit in the request.
+     *
+     * @return string
+     */
+    public function branch()
+    {
+        return isset($this->payload->ref)
+            ? str_replace('refs/heads/', '', $this->payload->ref)
+            : '';
+    }
+}

--- a/index.php
+++ b/index.php
@@ -4,7 +4,6 @@ namespace Nerrad\BuildMachine\WebHookListener;
 require 'vendor/autoload.php';
 
 use Exception;
-use Nerrad\BuildMachine\WebHookListener\Http\CodebaseRequest;
 use Nerrad\BuildMachine\WebHookListener\Http\RequestFactory;
 
 define('CB_WEBHOOK_BASE_PATH', __DIR__ . '/');
@@ -13,10 +12,11 @@ define('CB_WEBHOOK_BASE_PATH', __DIR__ . '/');
 try {
     $config = new Config();
     //grab request and pass to React class.
-    $request = RequestFactory::getRequestForRepositoryType($_REQUEST, $config->repository_type);
+    $request = RequestFactory::getRequestForRepositoryType($_REQUEST);
     new React($request, $config);
 } catch (Exception $e) {
     $msg = $e->getMessage();
+    error_log($msg);
     header($msg, true, 501);
     exit();
 }


### PR DESCRIPTION
The various repository services have unique ways of identifying them (via headers or user-agent).  This allows us to do auto-detection of the repository type rather than having the user configure it and also allows for the same webhook listener to handle pushes from multiple different repositories.